### PR TITLE
fix: Impressum — § 18 Abs. 2 MStV Sektion entfernt

### DIFF
--- a/impressum.md
+++ b/impressum.md
@@ -89,22 +89,6 @@ robots: noindex, nofollow
       </div>
     </section>
 
-    <section class="legal-section contact-info">
-      <h2 class="section-heading">Verantwortlich i.S.d. § 18 Abs. 2 MStV</h2>
-      <div class="contact-card">
-        <div class="contact-details">
-          <div class="contact-item">
-            <span class="contact-label">Name:</span>
-            <span class="contact-value">Thomas Schuster</span>
-          </div>
-          <div class="contact-item">
-            <span class="contact-label">Anschrift:</span>
-            <!-- TODO: Privatadresse einsetzen (wie oben) -->
-          </div>
-        </div>
-      </div>
-    </section>
-
     <section class="legal-section">
       <h2 class="section-heading">Steuerliche Angaben</h2>
       <div class="contact-card">

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -108,7 +108,7 @@ describe('Jekyll Site Integration Tests', () => {
       const impressumPath = path.join(projectRoot, 'impressum.md');
       const content = fs.readFileSync(impressumPath, 'utf8');
 
-      const legalRequirements = ['Thomas Schuster', '§ 5 DDG', 'MStV', 'E-Mail'];
+      const legalRequirements = ['Thomas Schuster', '§ 5 DDG', 'E-Mail'];
 
       legalRequirements.forEach(requirement => {
         expect(content).toMatch(new RegExp(requirement, 'i'));


### PR DESCRIPTION
## Summary

- § 18 Abs. 2 MStV gilt nur bei journalistisch-redaktionellen Inhalten (Blog, News, regelmäßige Artikel)
- kingsepp.dev ist Portfolio + Leistungsseiten → keine Pflicht
- Sektion inkl. offenem TODO (leere Adresse) entfernt
- Test-Assertion `MStV` aus `legalRequirements` entfernt

🤖 Generated with [Claude Code](https://claude.com/claude-code)